### PR TITLE
Encode library.properties as UTF-8

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-﻿name=DAC7611
+name=DAC7611
 version=1.0.0
 author=Souvik Saha <souvikssaha@gmail.com>
 maintainer=Souvik Saha <souvikssaha@gmail.com>


### PR DESCRIPTION
The previous UTF-8 BOM encoding caused compilation of the library to fail with the error:
```
Missing 'name' from library in LIBRARYPATH
```
This will also be displayed as a warning on every compilation which does not include the library.

This issue might block your request for inclusion in the Arduino Library manager index: https://github.com/arduino/Arduino/issues/8311